### PR TITLE
Fix duplicate ZHLT keyvalues in half-life.fgd

### DIFF
--- a/Half-Life/half-life.fgd
+++ b/Half-Life/half-life.fgd
@@ -306,7 +306,7 @@
 	]
 ]
 
-@BaseClass base(Targetname, Targetx, Global, RenderFields, Effects, ZHLT) = Breakable
+@BaseClass base(Targetname, Targetx, Global, RenderFields, Effects) = Breakable
 [
 	health(integer) : "Strength" : 1
 	material(choices) : "Material type" : 0 =
@@ -450,7 +450,7 @@
 	]
 ]
 
-@BaseClass base(Targetname, Targetx, Master, Appearflags, RenderFields, Effects, ZHLT, Global, Angles, LockedSounds) = Door
+@BaseClass base(Targetname, Targetx, Master, Appearflags, RenderFields, Effects, Global, Angles, LockedSounds) = Door
 [
 	speed(integer) : "Speed" : 100
 	movesnd(choices) : "Move Sound" : 0 = 
@@ -521,7 +521,7 @@
 	]
 ]
 
-@BaseClass base(Targetname, Target, RenderFields, Effects, Global, Angles, ZHLT) = BaseTank
+@BaseClass base(Targetname, Target, RenderFields, Effects, Global, Angles) = BaseTank
 [
 	spawnflags(flags) =
 	[
@@ -1100,7 +1100,7 @@
 // Functional Entities
 //
 
-@SolidClass base(Breakable) = func_breakable : "Breakable Object" []
+@SolidClass base(Breakable, ZHLT) = func_breakable : "Breakable Object" []
 
 @SolidClass base(Global, Targetname, Targetx, RenderFields, Angles, ZHLT, LockedSounds) = func_button : "Button" 
 [
@@ -1245,7 +1245,7 @@
 	rotation(integer) : "Spin amount" : 0
 ]
 
-@SolidClass base(Breakable) = func_pushable : "Pushable object"
+@SolidClass base(Breakable, ZHLT) = func_pushable : "Pushable object"
 [
 	size(choices) : "Hull Size" : 0 =
 	[


### PR DESCRIPTION
Fixes an issue where some brush entities like func_door and func_tank had duplicate ZHLT keyvalues.

The definitions for these brush entities include `ZHLT` as a baseclass, but their other baseclasses (namely `BaseTank`, `Breakable`, and `Door`) were already including `ZHLT`, so I removed `ZHLT` from the baseclasses.

Note that `func_breakable` and `func_pushable` did not have this issue as their definitions did not include `ZHLT`; they do so now for the sake of consistency.

Changes:
- Removed `ZHLT` from `BaseTank`, `Breakable`, and `Door` baseclasses
- Added `ZHLT` baseclass to `func_breakable` and `func_pushable` individually